### PR TITLE
Added new "Address" categories

### DIFF
--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressBccCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressBccCategoryProvider.rb
@@ -1,0 +1,30 @@
+class AddressBccCategoryProvider < CategoryProviderBase
+	def category_label
+		return "Address - BCC"
+	end
+
+	def label
+		return "Address - BCC (within scope)"
+	end
+
+	def can_be_column
+		return false
+	end
+
+	def named_queries(scope_query)
+		bcc_distinct_addresses = {}
+
+		scope_items = $current_case.search(scope_query)
+		scope_items.each do |item|
+			comm = item.getCommunication
+			if !comm.nil?
+				comm.getBcc.map{|address_obj| bcc_distinct_addresses[address_obj.getAddress.downcase] = true}
+			end
+		end
+
+		result = []
+		result += bcc_distinct_addresses.keys.map{|address| NamedQuery.new(address,"bcc:\"#{address}\"")}
+		result = result.sort_by{|nq| nq.getName}
+		return result
+	end
+end

--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressCategoryProvider.rb
@@ -1,0 +1,33 @@
+class AddressCategoryProvider < CategoryProviderBase
+	def category_label
+		return "Address"
+	end
+
+	def label
+		return "Address (within scope)"
+	end
+
+	def can_be_column
+		return false
+	end
+
+	def named_queries(scope_query)
+		distinct_addresses = {}
+		
+		scope_items = $current_case.search(scope_query)
+		scope_items.each do |item|
+			comm = item.getCommunication
+			if !comm.nil?
+				comm.getFrom.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+				comm.getTo.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+				comm.getCc.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+				comm.getBcc.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+			end
+		end
+
+		result = []
+		result += distinct_addresses.keys.map{|address| NamedQuery.new(address,"from:\"#{address}\" OR to:\"#{address}\" OR cc:\"#{address}\" OR bcc:\"#{address}\"")}
+		result = result.sort_by{|nq| nq.getName}
+		return result
+	end
+end

--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressCcCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressCcCategoryProvider.rb
@@ -1,0 +1,30 @@
+class AddressCcCategoryProvider < CategoryProviderBase
+	def category_label
+		return "Address - CC"
+	end
+
+	def label
+		return "Address - CC (within scope)"
+	end
+
+	def can_be_column
+		return false
+	end
+
+	def named_queries(scope_query)
+		distinct_addresses = {}
+
+		scope_items = $current_case.search(scope_query)
+		scope_items.each do |item|
+			comm = item.getCommunication
+			if !comm.nil?
+				comm.getCc.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+			end
+		end
+
+		result = []
+		result += distinct_addresses.keys.sort.map{|address| NamedQuery.new(address,"cc:\"#{address}\"")}
+
+		return result
+	end
+end

--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressRecipientCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressRecipientCategoryProvider.rb
@@ -1,0 +1,32 @@
+class AddressRecipientCategoryProvider < CategoryProviderBase
+	def category_label
+		return "Address - Recipient"
+	end
+
+	def label
+		return "Address - Recipient (within scope)"
+	end
+
+	def can_be_column
+		return false
+	end
+
+	def named_queries(scope_query)
+		distinct_addresses = {}
+
+		scope_items = $current_case.search(scope_query)
+		scope_items.each do |item|
+			comm = item.getCommunication
+			if !comm.nil?
+				comm.getTo.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+				comm.getCc.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+				comm.getBcc.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+			end
+		end
+
+		result = []
+		result += distinct_addresses.keys.map{|address| NamedQuery.new(address,"to:\"#{address}\" OR cc:\"#{address}\" OR bcc:\"#{address}\"")}
+		result = result.sort_by{|nq| nq.getName}
+		return result
+	end
+end

--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressToCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/AddressToCategoryProvider.rb
@@ -1,0 +1,26 @@
+class AddressToCategoryProvider < CategoryProviderBase
+	def category_label
+		return "Address - To"
+	end
+
+	def label
+		return "Address - To (within scope)"
+	end
+
+	def named_queries(scope_query)
+		distinct_addresses = {}
+
+		scope_items = $current_case.search(scope_query)
+		scope_items.each do |item|
+			comm = item.getCommunication
+			if !comm.nil?
+				comm.getTo.map{|address_obj| distinct_addresses[address_obj.getAddress.downcase] = true}
+			end
+		end
+
+		result = []
+		result += distinct_addresses.keys.map{|address| NamedQuery.new(address,"to:\"#{address}\"")}
+		result = result.sort_by{|nq| nq.getName}
+		return result
+	end
+end

--- a/Ruby/IntersectionReport.nuixscript/CategoryProviders/ItemKindWithinScopeWithSummaryCategoryProvider.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviders/ItemKindWithinScopeWithSummaryCategoryProvider.rb
@@ -1,4 +1,4 @@
-class ItemKindWithinScopeCategoryProvider < CategoryProviderBase
+class ItemKindWithinScopeWithSummaryCategoryProvider < CategoryProviderBase
 	def label
 		return "Item Kind (Within Scope, With Summary)"
 	end


### PR DESCRIPTION
- Added category "Address"
- Added category "Address Recipients"
- Added category "Address - To"
- Added category "Address - CC"
- Added category "Address - BCC"
- Fixed duplicative category class "ItemKindWithinScopeCategoryProvider" which was causing the category "Item Kind (Within Scope)" to not show up in the list of choices