### PR TITLE
Added support for batch load date range filtering per sheet

### DIFF
--- a/Ruby/IntersectionReport.nuixscript/CategoryProviderBase.rb
+++ b/Ruby/IntersectionReport.nuixscript/CategoryProviderBase.rb
@@ -23,6 +23,25 @@ class CategoryProviderBase
 		@@terms = value
 	end
 
+	@@search_content_for_terms = true
+	@@search_properties_for_terms = true
+
+	def self.search_content_for_terms
+		return @@search_content_for_terms
+	end
+
+	def self.search_content_for_terms=(value)
+		@@search_content_for_terms = value
+	end
+
+	def self.search_properties_for_terms
+		return @@search_properties_for_terms
+	end
+
+	def self.search_properties_for_terms=(value)
+		@@search_properties_for_terms = value
+	end
+
 	@@noise_terms = {}
 	def self.noise_terms
 		return @@noise_terms


### PR DESCRIPTION
Can now specify that results on a given sheet should be restricted to items which belong to a batch load which has a loaded date that falls within a specified range.